### PR TITLE
Hide unnecessary actuator endpoints

### DIFF
--- a/spring/src/main/resources/application.properties
+++ b/spring/src/main/resources/application.properties
@@ -4,7 +4,6 @@ email.sender: Markus Malkusch <markus@malkusch.de>
 ; otherwise mail transport is not available.
 ; For further mail configuration see http://docs.spring.io/spring-boot/docs/current/api/index.html?org/springframework/boot/autoconfigure/mail/MailProperties.html
 ;
-spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
@@ -20,4 +19,6 @@ recovery.lifetime: P1D
 ; The length of the generated password.
 recovery.length: 32
 
-management.security.enabled = false
+endpoints.enabled=false
+endpoints.info.enabled=true
+endpoints.health.enabled=true


### PR DESCRIPTION
Use spring book configuration to expose only the required actuator endpoints like /health

Signed-off-by: Fabio Oliveira <fabio.braga@gmail.com>